### PR TITLE
PRs no longer build on Windows and macOS

### DIFF
--- a/.github/workflows/grade.yml
+++ b/.github/workflows/grade.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
 
     steps:


### PR DESCRIPTION
This is because GitHub minutes cost money and we don't want to spend money. It still builds on Linux.